### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python Diamond/dia.py --stack Diamond/main.d"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Run on Repl.it](https://repl.it/badge/github/crohn64/Diamond)](https://repl.it/github/crohn64/Diamond)
 # Diamond Programming Language
 ![Diamond logo](/images/logo.PNG)
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@faas/Diamond).